### PR TITLE
Add note about installing vim-mustache-handlebars

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Highlight inline hbs tagged template literals using mustache sytax.
 
 Use your favorite installation method, such as [Plug](https://github.com/junegunn/vim-plug).
 
+```vim
+Plug 'dustinfarris/vim-htmlbars-inline-syntax'
+```
+
+Make sure you have installed [vim-mustache-handlebars](https://github.com/mustache/vim-mustache-handlebars).
+
 
 ## Usage
 


### PR DESCRIPTION
When I first installed this plugin I kept getting an error saying that the syntax/mustache.vim file couldn't be found. I eventually figured out that I was using a deprecated vim plugin and that vim-htmlbars-inline-syntax works. It may be helpful to include this information in the README. 